### PR TITLE
chore(readme): change paths

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,13 +21,13 @@ var gulp = require('gulp');
 var conventionalChangelog = require('gulp-conventional-changelog');
 
 gulp.task('default', function () {
-  return gulp.src('CHANGELOG.md', {
+  return gulp.src('./CHANGELOG.md', {
     buffer: false
   })
     .pipe(conventionalChangelog({
       preset: 'angular'
     }))
-    .pipe(gulp.dest('CHANGELOG.md'));
+    .pipe(gulp.dest('./'));
 });
 ```
 
@@ -38,11 +38,11 @@ var gulp = require('gulp');
 var conventionalChangelog = require('gulp-conventional-changelog');
 
 gulp.task('default', function () {
-  return gulp.src('CHANGELOG.md')
+  return gulp.src('./CHANGELOG.md')
     .pipe(conventionalChangelog({
       preset: 'angular'
     }))
-    .pipe(gulp.dest('CHANGELOG.md'));
+    .pipe(gulp.dest('./'));
 });
 ```
 


### PR DESCRIPTION
Fixed gulp.dest paths cause gulp is trying to create mkdir CHANGELOG.md
